### PR TITLE
CaselessFs

### DIFF
--- a/src/caseless.rs
+++ b/src/caseless.rs
@@ -1,0 +1,134 @@
+//! This module contains a caseless filesystem.
+
+use std::ffi::OsString;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use crate::index::normalize_path;
+use crate::prelude::*;
+use crate::store::Entries;
+
+/// Caseless filesystem wrapping an inner filesystem.
+#[derive(Clone, Debug)]
+pub struct CaselessFs<T> {
+    /// Inner filesystem store.
+    inner: T,
+}
+
+impl<T: Store> CaselessFs<T> {
+    /// Creates a new caseless filesystem with the provided inner filesystem.
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    /// Moves the inner filesystem out of the caseless filesystem.
+    /// Inspired by std::io::Cursor.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    /// Gets a reference to the inner filesystem.
+    /// Inspired by std::io::Cursor.
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the inner filesystem.
+    /// Inspired by std::io::Cursor.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Finds paths that match the caseless path.
+    pub fn find<P: AsRef<Path>>(&self, path: P) -> Vec<PathBuf> {
+        self.find_path(&normalize_path(path.as_ref()))
+    }
+
+    /// Finds paths that match the caseless path.
+    pub fn find_path(&self, path: &Path) -> Vec<PathBuf> {
+        let mut paths = vec![PathBuf::new()];
+        for component in path.components() {
+            paths = find_next_ascii_lowercase(&self.inner, &component, paths);
+            if paths.len() == 0 {
+                return paths;
+            }
+        }
+        paths
+    }
+}
+
+impl<T: Store> Store for CaselessFs<T> {
+    type File = T::File;
+
+    /// Opens the file of the caseless path.
+    fn open_path(&self, path: &Path) -> io::Result<Self::File> {
+        // real path
+        if let Ok(file) = self.inner.open_path(path) {
+            return Ok(file);
+        }
+        // caseless path
+        for path in self.find_path(path) {
+            return self.inner.open_path(&path);
+        }
+        Err(io::ErrorKind::NotFound.into())
+    }
+
+    /// Iterates over the entries of the inner filesystem.
+    fn entries_path(&self, path: &Path) -> io::Result<Entries> {
+        self.inner.entries_path(path)
+    }
+}
+
+/// Finds the next path candidates.
+fn find_next_ascii_lowercase<S: Store>(
+    fs: &S,
+    component: &Component,
+    paths: Vec<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut next = Vec::new();
+    let target: OsString = match component {
+        Component::Normal(os_s) => (*os_s).to_owned(),
+        Component::RootDir => {
+            // nothing can go before the root
+            next.push(Path::new("/").to_owned());
+            return next;
+        }
+        _ => {
+            panic!(format!("unexpected path component {:?}", component));
+        }
+    };
+    if let Some(t_s) = target.to_str() {
+        // compare utf8
+        for path in paths {
+            if let Ok(entries) = fs.entries(&path) {
+                for e in entries {
+                    if let Ok(entry) = e {
+                        if let Some(e_s) = entry.name.to_str() {
+                            if t_s.to_ascii_lowercase() == e_s.to_ascii_lowercase() {
+                                let mut path = path.to_owned();
+                                path.push(&entry.name);
+                                next.push(path);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        // compare raw
+        for path in paths {
+            if let Ok(entries) = fs.entries(&path) {
+                for e in entries {
+                    if let Ok(entry) = e {
+                        if &entry.name == &target {
+                            let mut path = path.to_owned();
+                            path.push(&entry.name);
+                            next.push(path);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    next
+}

--- a/src/caseless.rs
+++ b/src/caseless.rs
@@ -22,33 +22,33 @@ use crate::store::Entries;
 
 /// Caseless filesystem wrapping an inner filesystem.
 #[derive(Clone, Debug)]
-pub struct CaselessFs<T> {
+pub struct CaselessFs<S> {
     /// Inner filesystem store.
-    inner: T,
+    inner: S,
 }
 
-impl<T: Store> CaselessFs<T> {
+impl<S: Store> CaselessFs<S> {
     /// Creates a new caseless filesystem with the provided inner filesystem.
     /// It treats paths as case-insensitive, regardless of the case of the inner filesystem.
-    pub fn new(inner: T) -> Self {
+    pub fn new(inner: S) -> Self {
         Self { inner }
     }
 
     /// Moves the inner filesystem out of the caseless filesystem.
     /// Inspired by std::io::Cursor.
-    pub fn into_inner(self) -> T {
+    pub fn into_inner(self) -> S {
         self.inner
     }
 
     /// Gets a reference to the inner filesystem.
     /// Inspired by std::io::Cursor.
-    pub fn get_ref(&self) -> &T {
+    pub fn get_ref(&self) -> &S {
         &self.inner
     }
 
     /// Gets a mutable reference to the inner filesystem.
     /// Inspired by std::io::Cursor.
-    pub fn get_mut(&mut self) -> &mut T {
+    pub fn get_mut(&mut self) -> &mut S {
         &mut self.inner
     }
 
@@ -68,8 +68,8 @@ impl<T: Store> CaselessFs<T> {
     }
 }
 
-impl<T: Store> Store for CaselessFs<T> {
-    type File = T::File;
+impl<S: Store> Store for CaselessFs<S> {
+    type File = S::File;
 
     /// Opens the file identified by the caseless path.
     /// A caseless path that matches the real path of a file always opens that file.

--- a/src/caseless.rs
+++ b/src/caseless.rs
@@ -41,11 +41,7 @@ impl<T: Store> CaselessFs<T> {
 
     /// Finds paths that match the caseless path.
     pub fn find<P: AsRef<Path>>(&self, path: P) -> Vec<PathBuf> {
-        self.find_path(&normalize_path(path.as_ref()))
-    }
-
-    /// Finds paths that match the caseless path.
-    pub fn find_path(&self, path: &Path) -> Vec<PathBuf> {
+        let path = normalize_path(path.as_ref());
         let mut paths = vec![PathBuf::new()];
         for component in path.components() {
             paths = find_next_ascii_lowercase(&self.inner, &component, paths);
@@ -67,7 +63,7 @@ impl<T: Store> Store for CaselessFs<T> {
             return Ok(file);
         }
         // caseless path
-        for path in self.find_path(path) {
+        for path in self.find(path) {
             return self.inner.open_path(&path);
         }
         Err(io::ErrorKind::NotFound.into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::{env, fs};
 
+pub use caseless::CaselessFs;
 //pub use index::{Index, IndexEntries};
 pub use store::{Entries, Entry, EntryKind, Store, StoreExt};
 #[cfg(feature = "tar")]
@@ -63,6 +64,7 @@ pub use zip::ZipFs;
 
 include!("macros.rs");
 
+pub mod caseless;
 /// Directory index.
 #[doc(hidden)]
 pub mod index;

--- a/tests/caseless.rs
+++ b/tests/caseless.rs
@@ -1,0 +1,59 @@
+use std::io::prelude::*;
+
+use mini_fs::prelude::*;
+use mini_fs::{CaselessFs, RamFs};
+
+#[cfg(test)]
+#[test]
+fn caseless() {
+    let mut ram = RamFs::new();
+    ram.touch("/a.txt", b"low a".to_vec());
+    ram.touch("/A.TXT", b"high a".to_vec());
+    ram.touch("/b/b.txt", b"low b".to_vec());
+    ram.touch("/B/B.TXT", b"high b".to_vec());
+    let mut caseless = CaselessFs::new(ram);
+
+    // open with exact path
+    let mut txt = String::new();
+    let mut file = caseless.open("/a.txt").unwrap();
+    file.read_to_string(&mut txt).unwrap();
+    assert_eq!("low a", txt);
+
+    let mut txt = String::new();
+    let mut file = caseless.open("/A.TXT").unwrap();
+    file.read_to_string(&mut txt).unwrap();
+    assert_eq!("high a", txt);
+
+    let mut txt = String::new();
+    let mut file = caseless.open("/b/b.txt").unwrap();
+    file.read_to_string(&mut txt).unwrap();
+    assert_eq!("low b", txt);
+
+    let mut txt = String::new();
+    let mut file = caseless.open("/B/B.TXT").unwrap();
+    file.read_to_string(&mut txt).unwrap();
+    assert_eq!("high b", txt);
+
+    // add with get_mut
+    caseless.get_mut().touch("/c.txt", b"c".to_vec());
+    let mut txt = String::new();
+    let mut file = caseless.open("/c.txt").unwrap();
+    file.read_to_string(&mut txt).unwrap();
+    assert_eq!("c", txt);
+
+    // find with caseless path
+    assert_eq!(caseless.find("/A.txt").len(), 2);
+
+    assert_eq!(caseless.find("/b/B.txt").len(), 2);
+
+    // open with caseless path
+    let mut txt = String::new();
+    let mut file = caseless.open("/A.tXt").unwrap();
+    file.read_to_string(&mut txt).unwrap();
+    assert_eq!(["low a", "high a"].iter().any(|s| s == &txt), true);
+
+    let mut txt = String::new();
+    let mut file = caseless.open("/b/B.tXt").unwrap();
+    file.read_to_string(&mut txt).unwrap();
+    assert_eq!(["low b", "high b"].iter().any(|s| s == &txt), true);
+}


### PR DESCRIPTION
Inspired by std::io::Cursor.
It wraps a Store and allows you to open and find with caseless paths (using ascii lowercase).

Stuff I wanted but don't have enough rust knowledge to implement:
 * return an iterator in find ~/find_path~
 * allow other ways of comparing paths (lowercase, uppercase, ascii uppercase, custom)

PS- dealing with OsString's is hard, I wish there was an alternative to Path/PathBuf :(